### PR TITLE
changed login before_action to proper controller

### DIFF
--- a/ATS/app/controllers/index_controller.rb
+++ b/ATS/app/controllers/index_controller.rb
@@ -1,2 +1,3 @@
 class IndexController < ApplicationController
+    skip_before_action :require_login, only: [:index, :contact_support]
 end

--- a/ATS/app/controllers/welcome_controller.rb
+++ b/ATS/app/controllers/welcome_controller.rb
@@ -1,7 +1,6 @@
 require 'mailgun'
 
 class WelcomeController < ApplicationController
-  skip_before_action :require_login, only: [:index, :contact_support]
   # Ethan Widen 2/20/18
   def index
     @role = Role.find_by_id(session[:role_id])


### PR DESCRIPTION
Moved before_action from welcome controller (originally used in the Alumni Tracking System as the initial landing for a user) to the index controller (now used as the initial landing for a user). 

This commit forces the user to login before being able to access either system. Is that the effect desired?

In development the login requirement is ignored which is why this was not caught earlier. In the process of combining the two systems I failed to move the line that skips the before_action to the new controller that is initially hit by a user.